### PR TITLE
allow space-separated middle names or initials as part of given names

### DIFF
--- a/metatex2jats.py
+++ b/metatex2jats.py
@@ -46,12 +46,12 @@ def tex2jats(texname):
     pmid = ''
     publisherid = ''
     
-    prod_editor_givenname = meta[8][0].split(' ')[0]
-    prod_editor_surname = meta[8][0].split(' ')[1]
-    hand_editor_givenname = meta[9][0].split(' ')[0]
-    hand_editor_surname = meta[9][0].split(' ')[1]
-    copyed_givenname = meta[10][0].split(' ')[0]
-    copyed_surname = meta[10][0].split(' ')[1]
+    prod_editor_givenname = ' '.join(meta[8][0].split(' ')[:-1])
+    prod_editor_surname = meta[8][0].split(' ')[-1]
+    hand_editor_givenname = ' '.join(meta[9][0].split(' ')[:-1])
+    hand_editor_surname = meta[9][0].split(' ')[-1]
+    copyed_givenname = ' '.join(meta[10][0].split(' ')[:-1])
+    copyed_surname = meta[10][0].split(' ')[-1]
     
     formats = ["%B %d, %Y", "%B %d %Y", "%d %B %Y", "%b %d %Y", "%m/%d/%Y", "%m %d %Y"]
     dd = meta[1][0]


### PR DESCRIPTION
I just added a quick fix for parsing editor names in the metadata - I usually include my middle initial and the previous version assumes only first and last names are present.