### PR TITLE
bug fix for xref for equation labels with :

### DIFF
--- a/cleanjats.py
+++ b/cleanjats.py
@@ -658,7 +658,7 @@ def cleanmathjats(xmlname, mathmode):
             regex = r"(\\label\{(\S*?)\})"
             label = re.findall(regex, str(newtag) )[0][1]
             p["id"] = label
-            ids.append(label)
+            ids.append(re.sub(r':',r'U003A',label))
             
             labeltag = soup.new_tag("label")
             p.append(labeltag)


### PR DESCRIPTION
if equation labels have : in them (which seems to be a common convention) pandoc changes the rid attribute in the xrefs so cleanmathjats() doesn't catch them properly and all the xrefs in the XML galley end up having the author-defined label text in them instead of the equation number; added one regex to fix that.